### PR TITLE
adjust readme to work with latest ecs version

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,17 @@
 2. Register formatter in your `ecs.php`
 
 ```php
-return static function (ECSConfig $config): void {
-    [...]
+use Reinfi\EasyCodingStandard\JUnitOutputFormatter;
+use Symplify\EasyCodingStandard\Config\ECSConfig;
+use Symplify\EasyCodingStandard\Contract\Console\Output\OutputFormatterInterface;
 
-    $configurator->tag(JUnitOutputFormatter::class, OutputFormatterInterface::class);
-};
+if (isset($ecsConfig) && $ecsConfig instanceof ECSConfig) {
+    $ecsConfig->tag(JUnitOutputFormatter::class, OutputFormatterInterface::class);
+}
+
+return ECSConfig::configure()
+    [...]
+    ->withPaths([__DIR__ . '/src']);
 ```
 
 ### Usage

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "require-dev": {
         "phpstan/phpstan": "^1.9",
         "phpstan/phpstan-phpunit": "^1.3",
-        "symplify/easy-coding-standard": "^12"
+        "symplify/easy-coding-standard": "> 12.1.4"
     },
     "autoload": {
         "psr-4": {

--- a/ecs.php
+++ b/ecs.php
@@ -3,20 +3,8 @@
 declare(strict_types=1);
 
 use Symplify\EasyCodingStandard\Config\ECSConfig;
-use Symplify\EasyCodingStandard\ValueObject\Set\SetList;
 
-return static function (ECSConfig $config): void {
-    $config->parallel();
-
-    $config->paths([
-        __DIR__ . '/src/',
-    ]);
-
-    $config->sets([
-        SetList::PSR_12,
-        SetList::COMMON,
-        SetList::CLEAN_CODE,
-    ]);
-
-    $config->lineEnding("\n");
-};
+return ECSConfig::configure()
+    ->withPaths([__DIR__ . '/src'])
+    ->withPreparedSets(psr12: true, common: true, symplify: true)
+    ->withRootFiles();

--- a/src/JUnitOutputFormatter.php
+++ b/src/JUnitOutputFormatter.php
@@ -61,10 +61,7 @@ final class JUnitOutputFormatter implements OutputFormatterInterface
 
         foreach ($errorAndDiffResult->getSystemErrors() as $systemError) {
             if ($systemError instanceof SystemError) {
-                $result .= $this->createTestCase(
-                    $systemError->getFileWithLine(),
-                    $systemError->getMessage()
-                );
+                $result .= $this->createTestCase($systemError->getFileWithLine(), $systemError->getMessage());
             }
         }
 


### PR DESCRIPTION
version 12.5 introduced new configuration format which now requires different tagging of output formatter. 