### PR TITLE
docs: update README to use singleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ use Symplify\EasyCodingStandard\Config\ECSConfig;
 use Symplify\EasyCodingStandard\Contract\Console\Output\OutputFormatterInterface;
 
 if (isset($ecsConfig) && $ecsConfig instanceof ECSConfig) {
-    $ecsConfig->tag(JUnitOutputFormatter::class, OutputFormatterInterface::class);
+    $ecsConfig->singleton(JUnitOutputFormatter::class);
 }
 
 return ECSConfig::configure()


### PR DESCRIPTION
This updates the documentation to use `singleton` instead of `tag`, relying on ECS's autotagging of Output Formatters.

For me, in ECS 12.1.14 it didn't work with `tag` as currently described in the docs, but worked when I changed it to `singleton` after a lot of trial and error :D 

 